### PR TITLE
Fix/cargo clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,8 @@ jobs:
           command: fmt
       - uses: actions-rs/cargo@v1
         with:
+          command: clippy
+      - uses: actions-rs/cargo@v1
+        with:
           command: build
           args: --release --all-features

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ However this might be the main project in which i'm going to continue maintainin
 
 ## Install
 
+From releases
+
 ```sh
 wget -qcO ~/.local/bin/switcher https://github.com/omarahm3/switcher/releases/download/v0.0.1-alpha/switcher
 chmod +x ~/.local/bin/switcher
+```
+
+Or install it as a cargo crate
+
+```sh
+cargo install switcher --version 0.0.1-alpha
 ```
 
 ## Build

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub fn get_program_info() -> ProgramInfo {
         Err(_) => panic!("Can't get current working directory"),
     };
 
-    if args.len() == 0 {
+    if args.is_empty() {
         // TODO should probably show help here
         println!("Please enter a valid command");
         exit(1);

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -17,7 +17,7 @@ impl AddProject {
 
         // TODO This is needed because if the command was passed with empty arguments then it will
         // somehow escape the None arm above
-        if args.len() == 0 {
+        if args.is_empty() {
             println!("You must specify at least the name of the project");
             exit(1);
         }
@@ -55,7 +55,7 @@ impl SyncProjectBranch {
             Some(args) => args,
         };
 
-        if args.len() == 0 {
+        if args.is_empty() {
             println!("You must specify project name and branch");
             exit(1);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn create(name: &String, path: &PathBuf) -> Project {
+    pub fn create(name: &str, path: &PathBuf) -> Project {
         Project {
             name: name.to_string(),
             path: path.to_path_buf(),
@@ -51,7 +51,7 @@ impl Config {
         }
     }
 
-    pub fn get_project(&mut self, project_name: &String) -> Option<&mut Project> {
+    pub fn get_project(&mut self, project_name: &str) -> Option<&mut Project> {
         self.projects
             .iter_mut()
             .find(|project| project.name == *project_name)

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,9 +46,8 @@ impl Config {
             Ok(file) => file,
         };
 
-        match file.write_all(content.as_bytes()) {
-            Err(err) => panic!("Error writing to config file: [{}]", err),
-            Ok(_) => {}
+        if let Err(err) = file.write_all(content.as_bytes()) {
+            panic!("Error writing to config file: [{}]", err)
         }
     }
 
@@ -82,10 +81,7 @@ pub fn print(program: ProgramInfo) {
         None => panic!("Cannot get config path"),
         Some(path) => path,
     };
-    let detail = match args.iter().find(|&arg| arg == "--detail" || arg == "-d") {
-        None => false,
-        Some(_) => true,
-    };
+    let detail = args.iter().find(|&arg| arg == "--detail" || arg == "-d").is_some();
 
     println!("Config path: [{}]", path);
     println!("Projects:");

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use crate::git::git_current_branch;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::prelude::*;
+use std::path::Path;
 use std::path::PathBuf;
 
 const CONFIG_INIT: &str = r#"
@@ -19,7 +20,7 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn create(name: &str, path: &PathBuf) -> Project {
+    pub fn create(name: &str, path: &Path) -> Project {
         Project {
             name: name.to_string(),
             path: path.to_path_buf(),
@@ -136,7 +137,7 @@ fn read_config_file(path: PathBuf) -> Config {
     }
 }
 
-fn handle_config_file(path: &PathBuf) {
+fn handle_config_file(path: &Path) {
     // Get parent directory path
     let parent_dir = match path.parent() {
         None => panic!("Error getting parent directory from path"),
@@ -156,11 +157,11 @@ fn handle_config_file(path: &PathBuf) {
     }
 }
 
-fn path_exists(path: &PathBuf) -> bool {
+fn path_exists(path: &Path) -> bool {
     fs::metadata(path).is_ok()
 }
 
-fn create_config_file(path: &PathBuf) {
+fn create_config_file(path: &Path) {
     // Create the actual config file
     let mut file = match fs::File::create(path) {
         Err(err) => panic!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,9 +168,8 @@ fn create_config_file(path: &Path) {
     };
 
     // Write an empty object to it
-    match file.write_all(CONFIG_INIT.as_bytes()) {
-        Err(err) => panic!("Error writing to config file: [{}]", err),
-        Ok(_) => {}
+    if let Err(err) = file.write_all(CONFIG_INIT.as_bytes()) {
+        panic!("Error writing to config file: [{}]", err);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ pub fn print(program: ProgramInfo) {
         None => panic!("Cannot get config path"),
         Some(path) => path,
     };
-    let detail = args.iter().find(|&arg| arg == "--detail" || arg == "-d").is_some();
+    let detail = args.iter().any(|arg| arg == "--detail" || arg == "-d");
 
     println!("Config path: [{}]", path);
     println!("Projects:");
@@ -106,7 +106,7 @@ pub fn print(program: ProgramInfo) {
 
             print!("\t\t\t\t{}", name);
 
-            if detail == true {
+            if detail {
                 let current_branch = git_current_branch(repository.to_path_buf());
                 // TODO properly handle the perfect alignment of the tabs
                 println!("  \t\t-> {}", current_branch);

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ pub fn print(program: ProgramInfo) {
                 // TODO properly handle the perfect alignment of the tabs
                 println!("  \t\t-> {}", current_branch);
             } else {
-                println!("");
+                println!();
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,9 +147,9 @@ fn handle_config_file(path: &Path) {
     };
 
     // Check config file
-    if !path_exists(&path) {
+    if !path_exists(path) {
         println!("Config doesn't exist, creating file");
-        create_config_file(&path);
+        create_config_file(path);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,9 +174,8 @@ fn create_config_file(path: &Path) {
 }
 
 fn create_config_directory(path: PathBuf) {
-    match fs::DirBuilder::new().recursive(true).create(path) {
-        Err(err) => panic!("Error creating config directory: [{}]", err),
-        Ok(_) => {}
+    if let Err(err) = fs::DirBuilder::new().recursive(true).create(path) {
+        panic!("Error creating config directory: [{}]", err);
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,8 +1,9 @@
 use std::fs;
 use std::path::PathBuf;
+use std::path::Path;
 use std::process::Command;
 
-pub fn get_repositories(path: &PathBuf) -> Vec<PathBuf> {
+pub fn get_repositories(path: &Path) -> Vec<PathBuf> {
     let mut repositories: Vec<PathBuf> = Vec::new();
 
     // TODO Must make sure that projects paths are directory the moment user enters them

--- a/src/git.rs
+++ b/src/git.rs
@@ -39,7 +39,7 @@ pub fn git_current_branch(repository: PathBuf) -> String {
     output
 }
 
-pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &String) {
+pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &str) {
     for repository in repositories {
         let repo_name = repository.file_name().unwrap().to_str().unwrap();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -40,7 +40,7 @@ pub fn git_current_branch(repository: PathBuf) -> String {
     output
 }
 
-pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &str) {
+pub fn sync_repositories_to_branch(repositories: &[PathBuf], branch: &str) {
     for repository in repositories {
         let repo_name = repository.file_name().unwrap().to_str().unwrap();
 
@@ -59,7 +59,7 @@ pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &str) {
 }
 
 fn build_command(command: &str) -> (String, Vec<&str>) {
-    let mut parts = command.trim().split(" ").collect::<Vec<&str>>();
+    let mut parts = command.trim().split(' ').collect::<Vec<&str>>();
     let command = &parts.remove(0);
     let args = &parts;
     (command.to_string(), args.to_vec())


### PR DESCRIPTION
`cargo clippy` output:

```
warning: using `println!("")`
   --> src/config.rs:117:17
    |
117 |                 println!("");
    |                 ^^^^^^^^^^^^ help: replace it with: `println!()`
    |
    = note: `#[warn(clippy::println_empty_string)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#println_empty_string

warning: length comparison to zero
  --> src/cli.rs:41:8
   |
41 |     if args.len() == 0 {
   |        ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `args.is_empty()`
   |
   = note: `#[warn(clippy::len_zero)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: length comparison to zero
  --> src/commands/projects.rs:20:12
   |
20 |         if args.len() == 0 {
   |            ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `args.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: length comparison to zero
  --> src/commands/projects.rs:58:12
   |
58 |         if args.len() == 0 {
   |            ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `args.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: unnecessary use of `to_vec`
   --> src/commands/projects.rs:173:38
    |
173 |     git::sync_repositories_to_branch(&repositories.to_vec(), &params.branch);
    |                                      ^^^^^^^^^^^^^^^^^^^^^^ help: use: `repositories`
    |
    = note: `#[warn(clippy::unnecessary_to_owned)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned

warning: writing `&String` instead of `&str` involves a new object where a slice will do
  --> src/config.rs:22:25
   |
22 |     pub fn create(name: &String, path: &PathBuf) -> Project {
   |                         ^^^^^^^ help: change this to: `&str`
   |
   = note: `#[warn(clippy::ptr_arg)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
  --> src/config.rs:22:40
   |
22 |     pub fn create(name: &String, path: &PathBuf) -> Project {
   |                                        ^^^^^^^^ help: change this to: `&Path`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
  --> src/config.rs:48:9
   |
48 | /         match file.write_all(content.as_bytes()) {
49 | |             Err(err) => panic!("Error writing to config file: [{}]", err),
50 | |             Ok(_) => {}
51 | |         }
   | |_________^ help: try this: `if let Err(err) = file.write_all(content.as_bytes()) { panic!("Error writing to config file: [{}]", err) }`
   |
   = note: `#[warn(clippy::single_match)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match

warning: writing `&String` instead of `&str` involves a new object where a slice will do
  --> src/config.rs:54:49
   |
54 |     pub fn get_project(&mut self, project_name: &String) -> Option<&mut Project> {
   |                                                 ^^^^^^^ help: change this to: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: redundant pattern matching, consider using `is_some()`
  --> src/config.rs:84:18
   |
84 |       let detail = match args.iter().find(|&arg| arg == "--detail" || arg == "-d") {
   |  __________________^
85 | |         None => false,
86 | |         Some(_) => true,
87 | |     };
   | |_____^ help: try this: `args.iter().find(|&arg| arg == "--detail" || arg == "-d").is_some()`
   |
   = note: `#[warn(clippy::redundant_pattern_matching)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching

warning: equality checks against true are unnecessary
   --> src/config.rs:112:16
    |
112 |             if detail == true {
    |                ^^^^^^^^^^^^^^ help: try simplifying it as shown: `detail`
    |
    = note: `#[warn(clippy::bool_comparison)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_comparison

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
   --> src/config.rs:139:29
    |
139 | fn handle_config_file(path: &PathBuf) {
    |                             ^^^^^^^^ help: change this to: `&Path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: this expression borrows a reference (`&std::path::PathBuf`) that is immediately dereferenced by the compiler
   --> src/config.rs:153:21
    |
153 |     if !path_exists(&path) {
    |                     ^^^^^ help: change this to: `path`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression borrows a reference (`&std::path::PathBuf`) that is immediately dereferenced by the compiler
   --> src/config.rs:155:28
    |
155 |         create_config_file(&path);
    |                            ^^^^^ help: change this to: `path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
   --> src/config.rs:159:22
    |
159 | fn path_exists(path: &PathBuf) -> bool {
    |                      ^^^^^^^^ help: change this to: `&Path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
   --> src/config.rs:163:29
    |
163 | fn create_config_file(path: &PathBuf) {
    |                             ^^^^^^^^ help: change this to: `&Path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/config.rs:174:5
    |
174 | /     match file.write_all(CONFIG_INIT.as_bytes()) {
175 | |         Err(err) => panic!("Error writing to config file: [{}]", err),
176 | |         Ok(_) => {}
177 | |     }
    | |_____^ help: try this: `if let Err(err) = file.write_all(CONFIG_INIT.as_bytes()) { panic!("Error writing to config file: [{}]", err) }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match

warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/config.rs:181:5
    |
181 | /     match fs::DirBuilder::new().recursive(true).create(path) {
182 | |         Err(err) => panic!("Error creating config directory: [{}]", err),
183 | |         Ok(_) => {}
184 | |     }
    | |_____^ help: try this: `if let Err(err) = fs::DirBuilder::new().recursive(true).create(path) { panic!("Error creating config directory: [{}]", err) }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match

warning: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
 --> src/git.rs:5:31
  |
5 | pub fn get_repositories(path: &PathBuf) -> Vec<PathBuf> {
  |                               ^^^^^^^^ help: change this to: `&Path`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices
  --> src/git.rs:42:50
   |
42 | pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &String) {
   |                                                  ^^^^^^^^^^^^^ help: change this to: `&[PathBuf]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&String` instead of `&str` involves a new object where a slice will do
  --> src/git.rs:42:73
   |
42 | pub fn sync_repositories_to_branch(repositories: &Vec<PathBuf>, branch: &String) {
   |                                                                         ^^^^^^^ help: change this to: `&str`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: single-character string constant used as pattern
  --> src/git.rs:61:42
   |
61 |     let mut parts = command.trim().split(" ").collect::<Vec<&str>>();
   |                                          ^^^ help: try using a `char` instead: `' '`
   |
   = note: `#[warn(clippy::single_char_pattern)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: `switcher` (bin "switcher") generated 22 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 14.71s
```